### PR TITLE
build: Add initial docs structure & config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,8 @@ author:
   name: A G Rakowski
   url: https://github.com/agrski
 repository: agrski/agrski.github.io
+
+theme: midnight
+locale: en_GB
+markdown: kramdown
+paginate: 1

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,8 @@
 title: Software for the Sedentary
 tagline: MLOps, musings, and more
+
+github_username: agrski
+author:
+  name: A G Rakowski
+  url: https://github.com/agrski
+repository: agrski/agrski.github.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+title: Software for the Sedentary
+tagline: MLOps, musings, and more


### PR DESCRIPTION
# Why
## Motivation
Adding a theme and setting various items of information provides a basis from which to add actual content.

The intent is to have the minimum required structure to use auto-generated Jekyll pages using GitHub Pages, without having to manually install Jekyll, Ruby, etc.

# What
## Changes
* Add `_config.yml` for Jekyll configuration.
* Add `index.md` as landing page.