### PR TITLE
build: Fix missing prefix in Jekyll theme name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ author:
   url: https://github.com/agrski
 repository: agrski/agrski.github.io
 
-theme: midnight
+theme: jekyll-theme-midnight
 locale: en_GB
 markdown: kramdown
 paginate: 1


### PR DESCRIPTION
# Why
## Motivation
According to the [GitHub docs](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll#adding-a-theme), the theme name should be of the form `jekyll-theme-<name>`.  I had inadvertently missed this prefix in #2.

# What
## Changes
* Add prefix to theme name in Jekyll config.