### PR TITLE
fix: Fix and update page layouts

### DIFF
--- a/docs/2023-12-22-test.md
+++ b/docs/2023-12-22-test.md
@@ -1,5 +1,4 @@
 ---
-layout: post
 title: "test"
 tags: tag1 tag2
 ---

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,3 +11,4 @@ theme: jekyll-theme-midnight
 locale: en_GB
 markdown: kramdown
 paginate: 1
+show_downloads: false

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: Software for the Sedentary
-tagline: MLOps, musings, and more
+description: MLOps, musings, and more
 
 github_username: agrski
 author:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
 ---
 layout: page
+title: {{ site.name }}
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,3 @@
 ---
-layout: page
 title: {{ site.name }}
 ---


### PR DESCRIPTION
# Why
## Motivation
The site does not render with the latest changes.  Checking the GH Pages build logs, there is this warning:
```
     Build Warning: Layout 'post' requested in 2023-12-22-test.md does not exist.
     Build Warning: Layout 'page' requested in index.md does not exist.
```

From checking the [layouts defined in the theme](https://github.com/pages-themes/midnight/tree/c7f251e648c8dee8458932a663c31c2f68fde9de/_layouts), there appears to be only a single, default layout, but nothing differentiating between posts and other pages.

As such, it looks like it'll be necessary to define these myself, but before doing so, I'd like to confirm if Jekyll will accept posts (and other parts of its directory structure!) without the full set-up.

# What
## Changes
* Set additional Jekyll config (description and a rule about showing download links).
* Set title in index page front matter.
* Remove page layouts.