### PR TITLE
fix(jekyll): Add style for attribution footer to theme

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,4 @@
+---
+---
+
+@import "{{ site.theme }}";

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -2,3 +2,23 @@
 ---
 
 @import "{{ site.theme }}";
+
+section {
+  #footer {
+    .credits {
+      font-size: 11px;
+      font-family: 'OpenSansRegular', "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-weight: normal;
+      color: #696969;
+      margin-top: -10px;
+
+      &.left {
+        float: left;
+      }
+
+      &.right {
+        float: right;
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why
## Motivation
Currently the attribution/credits footer is not styled as it would be if this information had been left in the title/header section.  It seems the base theme defines that style _only_ for the `#title` ID rather than for a class; see [here](https://github.com/pages-themes/midnight/blob/c7f251e648c8dee8458932a663c31c2f68fde9de/_sass/jekyll-theme-midnight.scss#L261).

The theme [defines](https://github.com/pages-themes/midnight#stylesheet) how to override the base stylesheet.

## Issues
Fixes #10 

# What
## Changes
* Add custom stylesheet defining a footer style for credits that matches that `title` section's style for the same.