### PR TITLE
feat: Rename blog and update attribution message

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: Software for the Sedentary
+title: Sourcery for the Sedentary
 description: MLOps, musings, and more
 
 github_username: agrski

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -30,7 +30,7 @@
 
         <div id="footer">
           <hr />
-          <span class="credits left">Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
+          <span class="credits left">A blog by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
           <span class="credits right">Copyright © 2023 <a href="{{ site.github.owner_url }}">{{ site.author.name }}</a></span>
         </div>
       </section>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -31,7 +31,7 @@
         <div id="footer">
           <hr />
           <span class="credits left">A blog by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
-          <span class="credits right">Copyright © 2023 <a href="{{ site.github.owner_url }}">{{ site.author.name }}</a></span>
+          <span class="credits right">Copyright © 2023 {{ site.author.name }}</span>
         </div>
       </section>
     </div>


### PR DESCRIPTION
# Why
## Motivation
Renaming the blog as the term "sourcery" (as a play on "source" for code and "sorcery" for mystic arts) sounds more engaging than "software".  There is furthermore a balance to first and last words now in terms of syllables.  It is also somewhat more general, as not all the content need strictly be about software, but more general about the magic of how things work, and so on.

For the attribution notices in the footer, repeating the GitHub link was redundant and this is better seen as a blog than a "project"; the latter term would make more sense in reference to a CLI application or client library.

# What
## Changes
* Rename blog title.
* Change wording in the attribution footer.