### PR TITLE
ci(github): Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
 # Why
 ## Motivation
 
+
+
 ## Issues
 Fixes #
 
 # What
 ## Changes
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+# Why
+## Motivation
+
+## Issues
+Fixes #
+
+# What
+## Changes


### PR DESCRIPTION
# Why
## Motivation
Having a template provides consistency and structure, along with convenience, for those creating PRs.

## Issues
* Fixes #14 

# What
## Changes
* Add PR template in a GitHub-compatible location.