### PR TITLE
build(jekyll): Add Google Analytics tracking

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,3 +12,4 @@ locale: en_GB
 markdown: kramdown
 paginate: 1
 show_downloads: false
+google_analytics: G-1LG33H6JPN

--- a/docs/_includes/head-custom-google-analytics.html
+++ b/docs/_includes/head-custom-google-analytics.html
@@ -1,0 +1,13 @@
+{% if site.google_analytics %}
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-1LG33H6JPN"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-1LG33H6JPN');
+</script>
+
+{% endif %}


### PR DESCRIPTION
# Why
## Motivation
As discussed in the linked issue, it'd be interesting to know how many people view pages of the blog, which pages are more popular over time or see spikes, whether people only start or also reach the end of pages, and so on.

Google Analytics is supported by the theme--see [here](https://github.com/pages-themes/midnight#configuration-variables) and [here](https://github.com/pages-themes/midnight#customizing-google-analytics-code).

## Issues
Fixes #15 

# What
## Changes
* Add Google Analytics measurement ID/tag ID.
* Add GTAG tracking script.

