### PR TITLE
build(jekyll): Remove site.name var from index page front matter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: {{ site.name }}
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.


### PR DESCRIPTION
# Why
## Motivation
The page title should be used by default as the HTML title, without needing this value to be explicitly set.
The `site.name` variable is thus superfluous, but also causing an odd issue of '{} || ...' being rendered as the title.
This is presumably something to do with how Jekyll, or one of the plug-ins in use, combines values to generate the site name.
[This GH issue](https://github.com/jekyll/jekyll-seo-tag/issues/238) for the Jekyll SEO plug-in suggests `site.title` is preferable in any case.

## Issues
N/A

# What
## Changes
* Remove explicit setting of title in index page front matter.

