### PR TITLE
build(jekyll): [#11] Add list of posts to index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,7 @@ layout: default
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+{% for post in site.posts %}
+* [{{ post.title }}]({{ post.url }})
+{% endfor %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,8 @@ layout: default
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
+---
+
 {% for post in site.posts %}
 * [{{ post.title }}]({{ post.url }})
   {{ post.date | date_to_string: "ordinal" }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,5 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 {% for post in site.posts %}
 * [{{ post.title }}]({{ post.url }})
+  {{ post.date | date_to_string: "ordinal" }}
 {% endfor %}


### PR DESCRIPTION
# Why
## Motivation
There needs to be some reasonable way of navigating to this blog's posts, and the index page is the natural location to have this.  However, the default layout of the Midnight theme does not provide this and, consequently, my modification of that default layout likewise lacks this functionality as yet.

## Issues
Fixes #11 

# What
## Changes
* Add templating for list of posts to index page.
