### PR TITLE
build(jekyll): Add blank line between post title and date in index page templating

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,5 +8,6 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 {% for post in site.posts %}
 * [{{ post.title }}]({{ post.url }})
+
   {{ post.date | date_to_string: "ordinal" }}
 {% endfor %}


### PR DESCRIPTION
# Why
## Motivation
The intention of introducing this blank line in the Liquid template is to force the date to be rendered on a new line in the HTML.

## Issues
Relates to #11, as a fix-up to PR #19 

# What
## Changes
* Add blank line in Liquid template for posts in index page.

