### PR TITLE
ci(github): Add CI workflow to check PR titles conform to Conventional Commit format

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,17 @@
+name: lint-pr-title
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title matches Conventional Commit format
+        uses: matthiashermsen/lint-pull-request-title@v1.0.0
+        with:
+          allowed-pull-request-types: build,ci,feat,fix,refactor,revert


### PR DESCRIPTION
# Why
## Motivation
I like consistency in the format of commits for any integration branch.  A simple way to enforce this is to use a CI workflow which checks that PR titles adhere to the [Conventional Commit (CC) format](https://www.conventionalcommits.org/en/v1.0.0/#specification), together with only using squash commits.  This format ensures certain information is present about the nature and scope of changes, without imposing any particular burden.

## Issues
Fixes #24

# What
## Changes
* Add GitHub CI workflow for linting PR titles according to the CC format.
  * This workflow applies to all PRs, not just those against integration branches like `master`.
* Restrict PR types to a smaller subset of the common ones applicable to this project.
