### PR TITLE
feat: Add licensing notice to blog index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Languages, both natural and programmatic, have likewise long held my fascination
 
 The view and opinions expressed in this blog are those of the author and do not necessarily represent the opinions of any organisation, employer, or other party, except where stated otherwise.
 
-This blog is made available under the terms of the Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0) licence.
+This blog is made available under the terms of the [Creative Commons Attribution-NonCommercial 4.0 International](https://creativecommons.org/licenses/by-nc/4.0/) (CC BY-NC 4.0) licence.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ Languages, both natural and programmatic, have likewise long held my fascination
 
 The view and opinions expressed in this blog are those of the author and do not necessarily represent the opinions of any organisation, employer, or other party, except where stated otherwise.
 
+This blog is made available under the terms of the Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0) licence.
+
 ---
 
 {% for post in site.posts %}


### PR DESCRIPTION
# Why
## Motivation
While the licensing/copyright terms for this blog are defined under `LICENSE.md` in the GitHub repository, this is not immediately obvious (or really visible at all) on the hosted site itself.  This PR rectifies that by adding an explicit statement to the same effect on the index/landing page.

## Issues
Fixes #25

# What
## Changes
* Add statement on licensing of blog content on site index page.