### PR TITLE
feat: Remove sentence on general CS topics from index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,6 @@ While the reader's body may presently be sedentary, I hope some of these article
 
 I mentioned that this blog will mostly be about software, although there may be tangents into other topics at times.
 Computer Science (CS) and software engineering are multi-disciplinary subjects encompassing a broad range of skills, which is what drew me to them.
-These subjects range from discrete maths and linear algebra to psychology and physiology in human-computer interactions to physics, electronics, and so much more!
 My own interests centre around statistics, machine learning (ML), and ML Ops; distributed systems; and more broadly around creating robust, efficient, evolvable systems.
 Languages, both natural and programmatic, have likewise long held my fascination, whether for dabbling in the esoteric and arcane or for more practical purposes.
 


### PR DESCRIPTION
# Why
## Motivation
The introduction to a blog should be brief and inform the reader about what _will_ be covered, rather than diverging into broad, general topics of discussion.  Part of the introduction to _this_ blog breaks that principle and, thus, should be removed.

## Issues
N/A

# What
## Changes
* Remove sentence from blog index page on CS at large.