### PR TITLE
ci(github): Remove extraneous blank lines from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,8 @@
 ## Motivation
 
 
-
 ## Issues
 Fixes #
 
 # What
 ## Changes
-
-


### PR DESCRIPTION
# Why
## Motivation
The GitHub PR template contains more blank lines between section headings that required.  I tend to write the motivation on the line immediately after the heading, meaning there is one redundant line there.  This also applies for the changes section, after which GitHub seems to add a further blank line of its own, although this could be due to the editor saving a new-line at the end of files.

## Issues
N/A

# What
## Changes
* Remove blank lines after the `Motivation` and `Changes` section headings.