### PR TITLE
build(jekyll): Add layout for blog posts

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
+    <script src="{{ '/assets/js/respond.js' | relative_url }}"></script>
+    <!--[if lt IE 9]>
+      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <!--[if lt IE 8]>
+    <link rel="stylesheet" href="{{ '/assets/css/ie.css' | relative_url }}">
+    <![endif]-->
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    {% include head-custom.html %}
+  </head>
+
+  <body>
+    <div class="wrapper">
+      <section>
+        <div id="title">
+          <h1>{{ site.title }}</h1>
+          <p>{{ site.description }}</p>
+        </div>
+
+        {{ content }}
+
+        <div id="footer">
+          <hr />
+          <span class="credits left">A blog by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
+          <span class="credits right">Copyright © 2023 {{ site.author.name }}</span>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -26,7 +26,7 @@
         </div>
 
         <h1>{{ page.title }}</h1>
-        <p>{{ page.date | date_to_string: "ordinal" }}
+        <p>{{ page.date | date_to_string: "ordinal" }} by {{ page.author | default: site.author.name }}</p>
 
         {{ content }}
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -25,6 +25,8 @@
           <a href={{ site.url }}><h1>{{ site.title }}</h1></a>
         </div>
 
+        <h1>{{ page.title }}</h1>
+
         {{ content }}
 
         <div id="footer">

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -23,7 +23,6 @@
       <section>
         <div id="title">
           <h1>{{ site.title }}</h1>
-          <p>{{ site.description }}</p>
         </div>
 
         {{ content }}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -26,6 +26,7 @@
         </div>
 
         <h1>{{ page.title }}</h1>
+        <p>{{ page.date | date_to_string: "ordinal" }}
 
         {{ content }}
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -22,7 +22,7 @@
     <div class="wrapper">
       <section>
         <div id="title">
-          <h1>{{ site.title }}</h1>
+          <a href={{ site.url }}><h1>{{ site.title }}</h1></a>
         </div>
 
         {{ content }}

--- a/docs/_posts/2023-12-22-test.md
+++ b/docs/_posts/2023-12-22-test.md
@@ -1,8 +1,6 @@
 ---
-title: "test"
+title: "Welcome to my test blog page"
 tags: tag1 tag2
 ---
-
-# Welcome to my test blog page
 
 This page is a test.

--- a/docs/_posts/2024-01-05-test.md
+++ b/docs/_posts/2024-01-05-test.md
@@ -1,0 +1,7 @@
+---
+title: "Welcome to my test blog page"
+author: AGR
+tags: tag1 tag2
+---
+
+This page is a test.

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -4,6 +4,13 @@
 @import "{{ site.theme }}";
 
 section {
+  #title {
+    a {
+      color: #e8e8e8;
+      font-weight: normal;
+    }
+  }
+
   #footer {
     .credits {
       font-size: 11px;


### PR DESCRIPTION
# Why
## Motivation
Posts have more specific metadata than is available for general pages.  This includes a publication date, an author (or authors), and a title.  The layout for posts should account for this additional information and display it in a suitable manner.

## Issues
Fixes #21

# What
## Changes
* Add post-specific layout with title, date, and author(s).
* Remove site description/tag-line for posts.
* Update CSS rules to not display site title on posts as a hyperlink unless hovered over.
* Add & update test blog posts to confirm layout behaves as expected.

## Deferred changes
* Handling of tags will be left for another PR, which should accommodate both tags on posts but also then displaying those on the index page.
* Any refactoring of the default and post layouts can be handled in the future, although this may require reinstating the site description for post pages.