### PR TITLE
build(jekyll): Update spacing between sections of post pages

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -27,7 +27,6 @@
 
         <h1>{{ page.title }}</h1>
         <p>{{ page.date | date_to_string: "ordinal" }} by {{ page.author | default: site.author.name }}</p>
-        <br />
 
         {{ content }}
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -27,6 +27,7 @@
 
         <h1>{{ page.title }}</h1>
         <p>{{ page.date | date_to_string: "ordinal" }} by {{ page.author | default: site.author.name }}</p>
+        <br />
 
         {{ content }}
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -26,7 +26,10 @@
         </div>
 
         <h1>{{ page.title }}</h1>
-        <p>{{ page.date | date_to_string: "ordinal" }} by {{ page.author | default: site.author.name }}</p>
+        <p class="metadata">
+          <span>{{ page.date | date_to_string: "ordinal" }}</span>
+          <span>{{ page.author | default: site.author.name }}</span>
+        </p>
 
         {{ content }}
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -4,6 +4,12 @@
 @import "{{ site.theme }}";
 
 section {
+  .metadata {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 30px;
+  }
+
   #title {
     a {
       color: #e8e8e8;

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -4,6 +4,7 @@
 @import "{{ site.theme }}";
 
 h1, h2, h3, h4, h5, h6 {
+  margin-top: 10px;
   margin-bottom: 20px;
 }
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -3,6 +3,10 @@
 
 @import "{{ site.theme }}";
 
+h1, h2, h3, h4, h5, h6 {
+  margin-bottom: 20px;
+}
+
 section {
   .metadata {
     display: flex;


### PR DESCRIPTION
# Why
## Motivation
Adding and adjusting the spacing between sections provides better visual separation between things like a post's title and its date and author.  It furthermore more clearly delimits the title and metadata from the actual post content.

## Issues
N/A

# What
## Changes
* Increase margins around all headings.
* Increase margins after post metadata (date & author).
* Justify post date & author to far ends of metadata line/paragraph.

Before:
![image](https://github.com/agrski/agrski.github.io/assets/20504869/53fe62e0-eed9-41c8-82b1-9d7e4f15fcff)

After (styling done in browser):
![image](https://github.com/agrski/agrski.github.io/assets/20504869/c2abdd32-8022-43e9-831f-4a0a93a6791a)
