### PR TITLE
build(jekyll): Change colour of site title link when in hover state

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -22,7 +22,7 @@
     <div class="wrapper">
       <section>
         <div id="title">
-          <a href={{ site.url }}><h1>{{ site.title }}</h1></a>
+          <h1><a href={{ site.url }}>{{ site.title }}</a></h1>
         </div>
 
         <h1>{{ page.title }}</h1>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -22,7 +22,9 @@
     <div class="wrapper">
       <section>
         <div id="title">
-          <h1><a href={{ site.url }}>{{ site.title }}</a></h1>
+          <h1>
+            <a href={{ site.url }}>{{ site.title }}</a>
+          </h1>
         </div>
 
         <h1>{{ page.title }}</h1>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -19,6 +19,10 @@ section {
     a {
       color: #e8e8e8;
       font-weight: normal;
+
+      &:hover {
+        color: #ffeb9b;
+      }
     }
   }
 


### PR DESCRIPTION
# Why
## Motivation
Currently the blog/site title does not change its appearance on hover, with the only visual indication it can be clicked coming from the change in cursor type. Changing the colour on hover would provide an additional, more obvious visual indication of how to navigate the site.

## Issues
Fixes #33 

# What
## Changes
* Add CSS to change the colour of the site title when in a hover state in the post layout.
* Change order of nesting of HTML elements to prevent new CSS rule being overridden.