### PR TITLE
build(jekyll): Refactor post layout with default layout as explicit base

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,7 +22,9 @@
     <div class="wrapper">
       <section>
         <div id="title">
-          <h1>{{ site.title }}</h1>
+          <h1>
+            <a href={{ site.url }}>{{ site.title }}</a>
+          </h1>
           <p>{{ site.description }}</p>
         </div>
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 <!doctype html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -2,49 +2,10 @@
 layout: default
 ---
 
-<!doctype html>
-<html lang="{{ site.lang | default: "en-US" }}">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<h1>{{ page.title }}</h1>
+<p class="metadata">
+  <span>{{ page.date | date_to_string: "ordinal" }}</span>
+  <span>{{ page.author | default: site.author.name }}</span>
+</p>
 
-{% seo %}
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
-    <script src="{{ '/assets/js/respond.js' | relative_url }}"></script>
-    <!--[if lt IE 9]>
-      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <!--[if lt IE 8]>
-    <link rel="stylesheet" href="{{ '/assets/css/ie.css' | relative_url }}">
-    <![endif]-->
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    {% include head-custom.html %}
-  </head>
-
-  <body>
-    <div class="wrapper">
-      <section>
-        <div id="title">
-          <h1>
-            <a href={{ site.url }}>{{ site.title }}</a>
-          </h1>
-        </div>
-
-        <h1>{{ page.title }}</h1>
-        <p class="metadata">
-          <span>{{ page.date | date_to_string: "ordinal" }}</span>
-          <span>{{ page.author | default: site.author.name }}</span>
-        </p>
-
-        {{ content }}
-
-        <div id="footer">
-          <hr />
-          <span class="credits left">A blog by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
-          <span class="credits right">Copyright © 2023 {{ site.author.name }}</span>
-        </div>
-      </section>
-    </div>
-  </body>
-</html>
+{{ content }}


### PR DESCRIPTION
# Why
## Motivation
The post layout prior to this PR differed only from the default layout in terms of its page-internal structure (i.e. `content` as understood by Jekyll/Liquid) and in not including the site description/tag-line in the header section of the page (not to be confused with the HTML header block).

This created a lot of redundancy in the layout definitions without providing much benefit; the removed tag-line is of minor importance, and the inclusion of a link from the site home-page back to itself is likewise of minor concern--it is not broken functionality but rather just irrelevant.

## Issues
Fixes #35 

# What
## Changes
* Always treat the site title as a link back to the home/index page.
* Always include the site description with the site title on pages.
* Remove redundant structure from the post layout so that only its differences from the default layout are defined.