### PR TITLE
build(jekyll): Add support for tags

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,3 +13,6 @@ markdown: kramdown
 paginate: 1
 show_downloads: false
 google_analytics: G-1LG33H6JPN
+
+kramdown:
+  auto_ids: true

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -9,8 +9,10 @@ layout: default
     {% assign tags = page.tags | sort %}
     {% for raw_tag in tags %}
     {% assign tag = raw_tag | slugify %}
+
     <a href="/tags#{{ tag }}">{{ tag }}</a>
     {% unless forloop.last %} | {% endunless %}
+
     {% endfor %}
   </span>
   <span>{{ page.author | default: site.author.name }}</span>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -6,7 +6,9 @@ layout: default
 <p class="metadata">
   <span>{{ page.date | date_to_string: "ordinal" }}</span>
   <span>
-    {% for tag in page.tags %}
+    {% assign tags = page.tags | sort %}
+    {% for raw_tag in tags %}
+    {% assign tag = raw_tag | slugify %}
     <a href="/tags#{{ tag }}">{{ tag }}</a>
     {% endfor %}
   </span>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -8,4 +8,10 @@ layout: default
   <span>{{ page.author | default: site.author.name }}</span>
 </p>
 
+<p class="metadata">
+  {% for tag in page.tags %}
+  <span>{{ tag }}</span>
+  {% endfor %}
+</p>
+
 {{ content }}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -10,7 +10,7 @@ layout: default
 
 <p class="metadata">
   {% for tag in page.tags %}
-  <span>{{ tag }}</span>
+  <a href="/tags#{{ tag }}">{{ tag }}</a>
   {% endfor %}
 </p>
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -5,13 +5,12 @@ layout: default
 <h1>{{ page.title }}</h1>
 <p class="metadata">
   <span>{{ page.date | date_to_string: "ordinal" }}</span>
+  <span>
+    {% for tag in page.tags %}
+    <a href="/tags#{{ tag }}">{{ tag }}</a>
+    {% endfor %}
+  </span>
   <span>{{ page.author | default: site.author.name }}</span>
-</p>
-
-<p class="metadata">
-  {% for tag in page.tags %}
-  <a href="/tags#{{ tag }}">{{ tag }}</a>
-  {% endfor %}
 </p>
 
 {{ content }}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -10,6 +10,7 @@ layout: default
     {% for raw_tag in tags %}
     {% assign tag = raw_tag | slugify %}
     <a href="/tags#{{ tag }}">{{ tag }}</a>
+    {% unless forloop.last %} | {% endunless %}
     {% endfor %}
   </span>
   <span>{{ page.author | default: site.author.name }}</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ This blog is made available under the terms of the [Creative Commons Attribution
 
 ---
 
-[Search by tag](/tags)
+[View by tag](/tags)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,10 @@ This blog is made available under the terms of the [Creative Commons Attribution
 
 ---
 
+[Search by tag](/tags)
+
+---
+
 {% for post in site.posts %}
 * [{{ post.title }}]({{ post.url }})
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,4 @@
+---
+layout: default
+---
+

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -2,3 +2,17 @@
 layout: default
 ---
 
+# Tags
+
+{% assign tags_and_posts = site.tags | sort %}
+{% for tag_and_posts in tags_and_posts %}
+  {% assign tag = tag_and_posts | first %}
+  {% assign posts = tag_and_posts | last %}
+
+  ## {{ tag }}
+
+  {% for post in posts %}
+    * [{{ post.title }}]({{ post.url }})
+  {% endfor %}
+
+{% endfor %}

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -13,6 +13,8 @@ layout: default
 
   {% for post in posts %}
     * [{{ post.title }}]({{ post.url }})
+
+      {{ post.date | date_to_string: "ordinal" }}
   {% endfor %}
 
 {% endfor %}

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -6,7 +6,7 @@ layout: default
 
 {% assign tags_and_posts = site.tags | sort %}
 {% for tag_and_posts in tags_and_posts %}
-  {% assign tag = tag_and_posts | first %}
+  {% assign tag = tag_and_posts | first | slugify %}
   {% assign posts = tag_and_posts | last %}
 
   ## {{ tag }}

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -12,9 +12,9 @@ layout: default
   ## {{ tag }}
 
   {% for post in posts %}
-    * [{{ post.title }}]({{ post.url }})
+  * [{{ post.title }}]({{ post.url }})
 
-      {{ post.date | date_to_string: "ordinal" }}
+    {{ post.date | date_to_string: "ordinal" }}
   {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
# Why
## Motivation
It is likely there will be multiple posts on the same topics or themes, which is what tags represent.  Being able to easily find all the posts for a given tag, and to look through available tags, making navigation around a site more convenient and useful to the end user (audience).

Jekyll has support for tags on posts and pages, but doesn't provide any standard mechanism for using these in the display of a site.  This PR allows the audience to easily view posts by tag and to navigate from a post to other posts with the same tag.

## Issues
Fixes #31 

# What
## Changes
* Ensure kramdown sets IDs for section headers in pages.
* Add page showing all posts/pages for each tag in the site.
* Add link from index page to tags page.
* Add links from post tags to sections in the tags page.