### PR TITLE
fix(jekyll): Fix indentation of tags page section headings

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -6,15 +6,15 @@ layout: default
 
 {% assign tags_and_posts = site.tags | sort %}
 {% for tag_and_posts in tags_and_posts %}
-  {% assign tag = tag_and_posts | first | slugify %}
-  {% assign posts = tag_and_posts | last %}
+{% assign tag = tag_and_posts | first | slugify %}
+{% assign posts = tag_and_posts | last %}
 
 ## {{ tag }}
 
-  {% for post in posts %}
+{% for post in posts %}
 * [{{ post.title }}]({{ post.url }})
 
   {{ post.date | date_to_string: "ordinal" }}
-  {% endfor %}
+{% endfor %}
 
 {% endfor %}

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -9,12 +9,12 @@ layout: default
   {% assign tag = tag_and_posts | first | slugify %}
   {% assign posts = tag_and_posts | last %}
 
-  ## {{ tag }}
+## {{ tag }}
 
   {% for post in posts %}
-  * [{{ post.title }}]({{ post.url }})
+* [{{ post.title }}]({{ post.url }})
 
-    {{ post.date | date_to_string: "ordinal" }}
+  {{ post.date | date_to_string: "ordinal" }}
   {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
# Why
## Motivation
This is a follow-up to PR #37.

The section headings within the Markdown for the tags page are not rendering correctly, as headings, due to being indented.  This can be seen in the below screenshot and the accompanying rendered HTML:
```html
<h1 id="tags">Tags</h1>

<p>## tag1</p>
```
![image](https://github.com/agrski/agrski.github.io/assets/20504869/26cde0ee-01d9-4e40-8216-e491aa108d03)

## Issues
Addresses #31 

# What
## Changes
* Reduce indentation of Markdown content in tags page.
* Reduce indentation of Liquid formatting in templating for tags page.