### PR TITLE
build: Add Makefile with utilities for creating posts and diagrams

### DIFF
--- a/.flowchart.mmd.tmpl
+++ b/.flowchart.mmd.tmpl
@@ -1,0 +1,14 @@
+---
+title: 
+---
+
+flowchart TB
+  classDef focusSystem      fill:#1168bd,stroke:#0b4884,color:#ffffff
+  classDef supportingSystem fill:#666,stroke:#0b4884,color:#ffffff
+  classDef consumingSystem  fill:#08427b,stroke:#052e56,color:#ffffff
+  classDef systemBoundary   fill:#eee,stroke:#ccc,stroke-width:2px,stroke-dasharray: 5 5
+
+  class  focusSystem
+  class  supportingSystem
+  class  consumingSystem
+  class  systemBoundary

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 SHELL := /usr/bin/env bash -o pipefail
 
+.PHONY: help
+help:
+	@echo Available commands:
+	@sed -rn '/^[a-zA-Z0-9_-]+:/ {s/:.*//; s/^/  /; p}' $(MAKEFILE_LIST)
+
 draft:
 	@echo hello
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL := /usr/bin/env bash -o pipefail
 
+.DEFAULT_GOAL := help
+
 .PHONY: help
 help:
 	@echo Available commands:

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,12 @@ help:
 	@echo Available commands:
 	@sed -rn '/^[a-zA-Z0-9_-]+:/ {s/:.*//; s/^/  /; p}' $(MAKEFILE_LIST)
 
+.draft_dir := docs/_drafts/
+.draft_suffix := .md
+f ?= $(error file name f must be set)
+
 draft:
-	@echo draft
+	@echo -e '---\ntitle: \ntags: \n---\n\n' > $(.draft_dir)/$(f)$(.draft_suffix)
 
 flowchart:
 	@echo flowchart

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@ help:
 .diagram_suffix := .mmd
 f ?= $(error file name f must be set)
 
+.PHONY: draft
 draft:
 	@echo -e '---\ntitle: \ntags: \n---\n\n' > $(.draft_dir)/$(f)$(.post_suffix)
 
+.PHONY: flowchart
 flowchart:
 	@cp .flowchart.mmd.tmpl $(.draft_dir)/$(f)$(.diagram_suffix)

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ draft:
 .PHONY: flowchart
 flowchart:
 	@cp .flowchart.mmd.tmpl $(.draft_dir)/$(f)$(.diagram_suffix)
+
+%.png: %.mmd
+	@mmdc -i $< -o $@
+	@convert $@ -pointsize 12 -fill grey50 label:"Copyright (C) agrski $$(date +%Y)" -gravity center -append $@

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help:
 .draft_dir := docs/_drafts
 .post_suffix := .md
 .diagram_suffix := .mmd
+.image_suffix := .png
 f ?= $(error file name f must be set)
 
 .PHONY: draft
@@ -20,6 +21,6 @@ draft:
 flowchart:
 	@cp .flowchart.mmd.tmpl $(.draft_dir)/$(f)$(.diagram_suffix)
 
-%.png: %.mmd
+%$(.image_suffix): %$(.diagram_suffix)
 	@mmdc -i $< -o $@
 	@convert $@ -pointsize 12 -fill grey50 label:"Copyright (C) agrski $$(date +%Y)" -gravity center -append $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+SHELL := /usr/bin/env bash -o pipefail

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo Available commands:
 	@sed -rn '/^[a-zA-Z0-9_-]+:/ {s/:.*//; s/^/  /; p}' $(MAKEFILE_LIST)
 
-.draft_dir := docs/_drafts/
+.draft_dir := docs/_drafts
 .post_suffix := .md
 .diagram_suffix := .mmd
 f ?= $(error file name f must be set)

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,7 @@
 SHELL := /usr/bin/env bash -o pipefail
+
+draft:
+	@echo hello
+
+flowchart:
+	@echo world

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 	@sed -rn '/^[a-zA-Z0-9_-]+:/ {s/:.*//; s/^/  /; p}' $(MAKEFILE_LIST)
 
 draft:
-	@echo hello
+	@echo draft
 
 flowchart:
-	@echo world
+	@echo flowchart

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ help:
 	@sed -rn '/^[a-zA-Z0-9_-]+:/ {s/:.*//; s/^/  /; p}' $(MAKEFILE_LIST)
 
 .draft_dir := docs/_drafts/
-.draft_suffix := .md
+.post_suffix := .md
 f ?= $(error file name f must be set)
 
 draft:
-	@echo -e '---\ntitle: \ntags: \n---\n\n' > $(.draft_dir)/$(f)$(.draft_suffix)
+	@echo -e '---\ntitle: \ntags: \n---\n\n' > $(.draft_dir)/$(f)$(.post_suffix)
 
 flowchart:
 	@echo flowchart

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,9 @@ flowchart:
 %$(.image_suffix): %$(.diagram_suffix)
 	@mmdc -i $< -o $@
 	@convert $@ -pointsize 12 -fill grey50 label:"Copyright (C) agrski $$(date +%Y)" -gravity center -append $@
+
+.diagrams := $(wildcard $(.draft_dir)/*$(.diagram_suffix))
+.images := $(.diagrams:$(.diagram_suffix)=$(.image_suffix))
+
+.PHONY: images
+images: $(.images)

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ help:
 
 .draft_dir := docs/_drafts/
 .post_suffix := .md
+.diagram_suffix := .mmd
 f ?= $(error file name f must be set)
 
 draft:
 	@echo -e '---\ntitle: \ntags: \n---\n\n' > $(.draft_dir)/$(f)$(.post_suffix)
 
 flowchart:
-	@echo flowchart
+	@cp .flowchart.mmd.tmpl $(.draft_dir)/$(f)$(.diagram_suffix)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /usr/bin/env bash -o pipefail
+SHELL := /usr/bin/env bash -o pipefail -o noclobber
 
 .DEFAULT_GOAL := help
 


### PR DESCRIPTION
# Why
## Motivation
From my experiences in #40, it was somewhat involved to create and run the appropriate commands for generating images from Mermaid diagrams, particularly when considering the inclusion of copyright notices for each image.  Regenerating these was also somewhat annoying, with the steps needing to be performed in the right order -- regenerating via `mmdc` didn't include the copyright notice, and re-running `convert` would add an additional such notice (thereby duplicating it).

In short, this process was ideal for automation.  Makefiles are a convenient way of defining reusable recipes, especially when there are files in nested directories, regular transformations of file names, and multiple files which may need to be reprocessed.  Makefiles have the further benefit that only _out of date_ files need to be reprocessed, which is faster and more efficient, particularly when there are many such files in existence.

In addition, posts and Mermaid diagrams all have some level of boilerplate common to each of them.  For posts, this is simply the front matter, whereas for diagrams it is not only the front matter but also definitions for styling classes of entities.  Rather than having to copy & paste this from existing diagrams, it is convenient to be able to generate these from pre-defined templates, in the process creating files with the appropriate names.

## Issues
* Fixes #41
* Fixes #42 

# What
## Changes
* Add Makefile at the project root.
* Add Make recipe for listing available commands/targets.
* Add Make recipe for creating new draft posts.
* Add Make recipe for creating new Mermaid diagrams for draft posts.
* Add Make recipe for (re)generating images from Mermaid diagrams.

## Testing
This has been tested with some of the files from #40.