### PR TITLE
fix(copyright): [#48] Update year in copyright notices

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
  # Blog Content
 
- The contents of the blog posts and other blog materials in this repository are © 2023 by [A G Rakowski (agrski)](https://github.com/agrski) and licensed under [CC BY-NC 4.0](http://creativecommons.org/licenses/by-nc/4.0/?ref=chooser-v1).
+ The contents of the blog posts and other blog materials in this repository are © 2024 by [A G Rakowski (agrski)](https://github.com/agrski) and licensed under [CC BY-NC 4.0](http://creativecommons.org/licenses/by-nc/4.0/?ref=chooser-v1).
  This includes all files under `docs/` except where indicated otherwise.
 
 # Other Files
@@ -9,7 +9,7 @@
 
 # The 3-Clause BSD License
 
- Copyright 2023 A G Rakowski
+ Copyright 2024 A G Rakowski
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -33,7 +33,7 @@
         <div id="footer">
           <hr />
           <span class="credits left">A blog by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
-          <span class="credits right">Copyright © 2023 {{ site.author.name }}</span>
+          <span class="credits right">Copyright © 2024 {{ site.author.name }}</span>
         </div>
       </section>
     </div>


### PR DESCRIPTION
# Why
## Motivation
It is good practice to keep the year up to date when asserting copyright.  This PR adjusts the stale references to 2023 to 2024.

## Issues
Fixes #48 

# What
## Changes
* Update licence.
* Update default page layout.